### PR TITLE
Algoritmi BibTex- avaimelle, avainlistaus, yhden viitteen tulostus

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -9,6 +9,7 @@ PAGES_FORMAT_ERROR = "Page numbers are not valid"
 EXTRA_KEYS_ERROR = "Input contains extra fields"
 FIELD_MANDATORY_ERROR = "Field is mandatory"
 UNSUITABLE_COMMAND_ERROR = "Unsuitable command"
+KEY_DOES_NOT_EXIST_ERROR = "Key does not exist"
 
 INPROCEEDINGS_KEYS = ["key", "title", "author", "booktitle", "year",
                       "editor", "volume", "series", "pages", "address",

--- a/src/data/references.bib
+++ b/src/data/references.bib
@@ -1,14 +1,14 @@
-@inproceedings{another,
+@inproceedings{doe20,
     title        = {An Example},
-    author       = {John Doe},
+    author       = {Doe, John},
     year         = 2020,
     booktitle    = {In Proceedings},
     address      = {Helsinki}
 }
 
-@inproceedings{mypaper,
+@inproceedings{smith22,
     title        = {An Analysis of Example},
-    author       = {John Smith and Jane Doe},
+    author       = {Smith, John and Doe, Jane},
     year         = 2022,
     month        = {June},
     booktitle    = {Proceedings of the International Conference on Example},
@@ -19,9 +19,17 @@
     pages        = {123--130},
     editor       = {David Brown and Susan Green},
 }
-@inproceedings{testpaper,
-    author       = {Austin Powers},
+@inproceedings{powers65,
+    author       = {Powers, Austin},
     title        = {Sometimes it is},
     booktitle    = {Understanding the importance of Mojo},
     year         = 1965
+}
+
+@inproceedings{doe20_1,
+    author       = {Doe, John},
+    title        = {An Example},
+    booktitle    = {In Proceedings},
+    year         = 2020,
+    address      = {Helsinki}
 }

--- a/src/repositories/reference_repository.py
+++ b/src/repositories/reference_repository.py
@@ -1,7 +1,7 @@
 """Module for saving references"""
 import bibtexparser
 from entities.reference import Inproceedings
-from constants import INPROCEEDINGS_KEYS, INPROCEEDINGS_MANDATORY_KEYS
+from constants import INPROCEEDINGS_KEYS, INPROCEEDINGS_MANDATORY_KEYS, KEY_DOES_NOT_EXIST_ERROR
 
 
 class ReferenceRepository:
@@ -66,6 +66,30 @@ class ReferenceRepository:
             list: List of all references
         """
         return self._references
+
+    def load_one(self, search_key):
+        """Retrieves reference by key
+
+        Args:
+            search_key (String): Key to determine correct reference
+        Raises:
+            ValueError: Raises, if key not found
+        Returns:
+            Reference: Reference or subclass object
+        """
+        reference = [ref for ref in self._references if ref.key == search_key]
+        if reference:
+            return reference[0]
+        raise ValueError(KEY_DOES_NOT_EXIST_ERROR)
+
+    def get_similar_key_count(self, key: str) -> int:
+        """Returns key substring occurrences in self._references
+        Args:
+            key (str): Key to be searched
+        Returns:
+            int: Amount of similar keys
+        """
+        return sum(key in reference.key for reference in self._references)
 
     def file_lines(self):
         """Helper function for testing

--- a/src/services/reference_services.py
+++ b/src/services/reference_services.py
@@ -88,11 +88,11 @@ class ReferenceServices:
             author = author.split(",")[0]
         if " " in author:
             author = author.replace(" ", "")
-        if len(author) >= 7:
+        if len(author) >= 8:
             author = author[:7]
         year = str(year)[2:]
-        bibtex = author + year
-        previous = self._reference_repository.get_similar_key_count(bibtex)
+        bibtex_key = author + year
+        previous = self._reference_repository.get_similar_key_count(bibtex_key)
         if previous > 0:
-            bibtex = bibtex + "_" + str(previous)
-        return bibtex
+            bibtex_key = bibtex_key + "_" + str(previous)
+        return bibtex_key

--- a/src/services/reference_services.py
+++ b/src/services/reference_services.py
@@ -19,7 +19,7 @@ class ReferenceServices:
         """
         self._reference_repository = reference_repository
 
-    def create_reference(self, reference):
+    def create_reference(self, reference: dict):
         """Validates reference dictionary fields
         generates Reference object and
         and calls reference_repository save method
@@ -29,8 +29,8 @@ class ReferenceServices:
         Args:
           reference (Reference): Refence object
         """
-
         ref_keys = reference.keys()
+        reference["key"] = self.construct_bibtex_key(reference["author"], reference["year"])
 
         if not all(item in INPROCEEDINGS_KEYS for item in ref_keys):
             raise ValueError(EXTRA_KEYS_ERROR)
@@ -72,3 +72,27 @@ class ReferenceServices:
             regex = r"^\d+([-]\d+)?$"
             if not re.match(regex, value):
                 raise ValueError(PAGES_FORMAT_ERROR)
+
+
+    def construct_bibtex_key(self, author: str, year: int) -> str:
+        """Algorithm for constucting bibtex -key.
+        if author: Powers and year: 2023 -> powers23
+        Expected author notation: {Lastname, Firstname}
+        In case for company name etc. notation does not matter.
+        Args:
+            author (String): Reference author
+            year (Int): Reference year
+        """
+        author = author.lower()
+        if "," in author:
+            author = author.split(",")[0]
+        if " " in author:
+            author = author.replace(" ", "")
+        if len(author) >= 7:
+            author = author[:7]
+        year = str(year)[2:]
+        bibtex = author + year
+        previous = self._reference_repository.get_similar_key_count(bibtex)
+        if previous > 0:
+            bibtex = bibtex + "_" + str(previous)
+        return bibtex

--- a/src/tests/reference_repository_test.py
+++ b/src/tests/reference_repository_test.py
@@ -1,8 +1,9 @@
 """Unittests for reference module"""
 import unittest
+import pytest
 from repositories.reference_repository import ReferenceRepository
-from entities.reference import Inproceedings
-from constants import ROOT_DIR
+from entities.reference import Inproceedings, Reference
+from constants import ROOT_DIR, KEY_DOES_NOT_EXIST_ERROR
 
 
 class TestReference(unittest.TestCase):
@@ -54,3 +55,22 @@ class TestReference(unittest.TestCase):
         reference_list = self.repository.load_all()
 
         self.assertEqual(1, len(reference_list))
+
+    def test_loading_one_from_empty_raises_error(self):
+        """Test for loading one reference when there are none"""
+        with pytest.raises(ValueError,
+                           match=KEY_DOES_NOT_EXIST_ERROR):
+            self.repository.load_one("test_key")
+
+    def test_loading_one_with_incorrect_key_raises_error(self):
+        """Test for loading one reference when key is wrong"""
+        self.repository.save(self.inpro_all)
+        with pytest.raises(ValueError,
+                           match=KEY_DOES_NOT_EXIST_ERROR):
+            self.repository.load_one("Key321")
+
+    def test_loading_one_returns_reference_object(self):
+        """Test succesfull retrieval"""
+        self.repository.save(self.inpro_all)
+        reference = self.repository.load_one("Key123")
+        assert issubclass(type(reference), Reference)

--- a/src/tests/reference_services_test.py
+++ b/src/tests/reference_services_test.py
@@ -21,7 +21,6 @@ class TestReferenceServices(unittest.TestCase):
         self.ref_services = ReferenceServices(self.repository)
 
         self.inpro = {
-            "key": "dockey12",
             "title": "Title",
             "author": "Ghost Writer",
             "booktitle": "Proceedings of the Conference",
@@ -54,23 +53,9 @@ class TestReferenceServices(unittest.TestCase):
         self.inpro["pages"] = "44"
         self.ref_services.create_reference(self.inpro)
 
-    def test_missing_key_raises_error(self):
-        """Test Value error with missing field key"""
-        self.inpro["key"] = None
-        with pytest.raises(ValueError,
-                           match=MISSING_FIELD_ERROR):
-            self.ref_services.create_reference(self.inpro)
-
     def test_missing_title_raises_error(self):
         """Test Value error with missing field title"""
         self.inpro["title"] = None
-        with pytest.raises(ValueError,
-                           match=MISSING_FIELD_ERROR):
-            self.ref_services.create_reference(self.inpro)
-
-    def test_missing_author_raises_error(self):
-        """Test Value error with missing field author"""
-        self.inpro["author"] = None
         with pytest.raises(ValueError,
                            match=MISSING_FIELD_ERROR):
             self.ref_services.create_reference(self.inpro)
@@ -129,7 +114,7 @@ class TestReferenceServices(unittest.TestCase):
         inpro = {
             "key": "dockey12",
             "title": "Title",
-            "author": "Ghost Writer",
+            "author": "Ghost, Writer",
             "booktitle": "Proceedings of the Conference",
             "year": 2023,
             "editor": "",
@@ -141,3 +126,26 @@ class TestReferenceServices(unittest.TestCase):
             "note": ""
         }
         self.ref_services.create_reference(inpro)
+    
+    def test_bibtex_key_generator(self):
+        """ Test for bibtex key constructing"""
+        inpro = {
+            "title": "How to Google",
+            "author": "Alphabet Inc.",
+            "booktitle": "Proceedings of the Conference",
+            "year": 2023,
+            "editor": "",
+            "volume": "",
+            "series": "",
+            "pages": "",
+            "address": "",
+            "month": "",
+            "note": ""
+        }
+        self.ref_services.create_reference(inpro)
+        key1 = self.ref_services.construct_bibtex_key("Powers", 2023)
+        key2 = self.ref_services.construct_bibtex_key("Powersson", 1995)
+        key3 = self.ref_services.construct_bibtex_key("Alphabet Inc.", 2023)
+        self.assertEqual(key1, "powers23")
+        self.assertEqual(key2, "powerss95")
+        self.assertEqual(key3, "alphabe23_1")

--- a/src/tests/ui_test.py
+++ b/src/tests/ui_test.py
@@ -1,11 +1,12 @@
 """Unittests for UI module."""
 import unittest
+import re
 from collections import deque
 from typing import List
 from repositories.reference_repository import ReferenceRepository
 from services.reference_services import ReferenceServices
 from ui import UI
-from constants import ROOT_DIR, UNSUITABLE_COMMAND_ERROR, FIELD_MANDATORY_ERROR, YEAR_FORMAT_ERROR
+from constants import ROOT_DIR, UNSUITABLE_COMMAND_ERROR, FIELD_MANDATORY_ERROR, YEAR_FORMAT_ERROR, KEY_DOES_NOT_EXIST_ERROR
 
 class MockIO:
     """Class to mock IO.
@@ -135,3 +136,46 @@ class TestUI(unittest.TestCase):
         ]
         output = self.run_program(command_list)
         self.assertIn(YEAR_FORMAT_ERROR, output)
+    
+    def test_show_all_reference_keys(self):
+        """Test showing all reference keys."""
+        command_list = [
+            "3",
+            "x"
+        ]
+        fields = {"title":"test title","author":"test author","booktitle":"test_title", "year":1995}
+        self.ref_services.create_reference(fields)
+        self.ref_services.create_reference(fields)
+        output = self.run_program(command_list)
+        self.assertEqual(output.count("testaut95"), len(self.ref_repository._references))
+
+    def test_show_reference_by_key(self):
+        """Test accessing single reference via ui"""
+        command_list = [
+            "3",
+            "k",
+            "testaut95",
+            "x",
+            "x"
+        ]
+        fields = {"title":"test title","author":"test author","booktitle":"test title", "year":1995}
+        expected_output = "@inproceedings{testaut95,\n"\
+                        "    author       = {test author},\n"\
+                        "    title        = {test title},\n"\
+                        "    booktitle    = {test title},\n"\
+                        "    year         = 1995\n"\
+                        "}"
+        self.ref_services.create_reference(fields)
+        self.ref_services.create_reference(fields)
+        output = self.run_program(command_list)
+        self.assertIn(expected_output, output)
+
+    def test_show_reference_by_invalid_key(self):
+        """Test for raising error if key does not exist"""
+        command_list = [
+            "3",
+            "invalid_key"
+        ]
+        output = self.run_program(command_list)
+        print(output)
+        self.assertIn(KEY_DOES_NOT_EXIST_ERROR, output)

--- a/src/ui.py
+++ b/src/ui.py
@@ -22,6 +22,7 @@ class UI():
         self.commands = {
             "1": "Browse all references",
             "2": "Add reference (inproceedings)",
+            "3": "View references by key",
             "c": "Show command options",
             "x": "Exit"
             # more commands added when needed
@@ -46,6 +47,9 @@ class UI():
 
             if command == "2":
                 self.add_inproceedings()
+
+            if command == "3":
+                self.show_reference_by_key()
 
             if command == "c":
                 self.show_commands()
@@ -79,7 +83,12 @@ class UI():
             mandatory_text = "optional, enter to skip"
 
         while True:
-            value = self._io.read(f"Enter value for field {field} ({mandatory_text}): ")
+            if field == "author":
+                value = self._io.read(
+                    f"Enter value for field {field} (Lastname, Firstname) ({mandatory_text}): "
+                    )
+            else:
+                value = self._io.read(f"Enter value for field {field} ({mandatory_text}): ")
             if value == "":
                 if mandatory:
                     self._io.write(f"Error: {field}: " + FIELD_MANDATORY_ERROR)
@@ -101,6 +110,8 @@ class UI():
         field_values = {}
 
         for field in INPROCEEDINGS_KEYS:
+            if field == "key":
+                continue
             mandatory = field in INPROCEEDINGS_MANDATORY_KEYS
             value = self.get_field(field, mandatory)
 
@@ -115,6 +126,35 @@ class UI():
         """Print references."""
         for reference in self._reference_repository.load_all():
             self._io.write(str(reference))
+
+    def show_one_reference(self, key: str) -> None:
+        """Print one reference with given key
+        Args:
+            key (String): Reference key
+        """
+        reference = self._reference_repository.load_one(key)
+        self._io.write(f"\n{str(reference)}")
+
+    def show_all_reference_keys(self) -> None:
+        """Print all keys"""
+        self._io.write("Keys:")
+        for reference in self._reference_repository.load_all():
+            self._io.write(f"   {reference.key}")
+
+    def show_reference_by_key(self) -> None:
+        """Loop for viewing references by key"""
+        self.show_all_reference_keys()
+        while True:
+            key = self._io.read("\nEnter key, 'k' for keys or 'x' for return: ")
+            if key == "x":
+                return
+            if key == "k":
+                self.show_all_reference_keys()
+            else:
+                try:
+                    self.show_one_reference(key)
+                except ValueError as error:
+                    self._io.write("Error: " + str(error))
 
     def exit(self):
         """Exit program."""


### PR DESCRIPTION
constants.py:
- KEY_DOES_NOT_EXIST_ERROR lisätty

reference_repository.py:
- load_one(key) metodi hakee yhden viitteen avaimella.
- get_similar_key_count(key) metodi palauttaa lukumäärän samoista merkkijonoista ja alijonoista avaimen muodostamista varten

reference_services.py:
- construct_bibtex_key(author, year) luo uuden referenssiavaimen. Ajatuksena että author kenttä olisi muotoa {Sukunimi, Etunimi}
- Enintään 7 kirjainta, 2 vuoden  viimeistä numeroa. Jos sama avain käytössä, perään _1, _2 jne..
- construct_bibtex_key() lisätty create_reference() metodin sisälle.

ui.py:
- Lisätty inputtiin muistutus author kirjoitusasusta.
- show_one_reference(key) hakee avaimella yhden viitteen ja tulostaa sen BibTex muodossa.
- show_all_reference_keys() hakee ja tulostaa kaikki käytössä olevat avaimet
- show_reference_by_key() looppaa kahta yllä mainittua käyttäjän syötteen mukaan.